### PR TITLE
Use correct value when checking Hotplug capability

### DIFF
--- a/src/LibUsbSharp/Internal/LibUsbCapability.cs
+++ b/src/LibUsbSharp/Internal/LibUsbCapability.cs
@@ -1,0 +1,18 @@
+﻿namespace LibUsbSharp.Internal;
+
+internal enum LibUsbCapability : uint
+{
+    /// <summary>
+    /// Hotplug support is available on this platform.
+    /// </summary>
+    HasHotplug = 0x0001,
+    /// <summary>
+    /// The library can access HID devices without requiring user intervention.
+    /// </summary>
+    HasHidAccess = 0x0100,
+    /// <summary>
+    /// The library supports detaching of the default USB driver,
+    /// using libusb_detach_kernel_driver(), if one is set by the OS kernel.
+    /// </summary>
+    SupportsDetachKernelDriver = 0x0101,
+}

--- a/src/LibUsbSharp/LibUsb.cs
+++ b/src/LibUsbSharp/LibUsb.cs
@@ -100,9 +100,8 @@ public sealed class LibUsb : ILibUsb
         ushort? productId = default
     )
     {
-        const int HotPlugCapability = 0x00000004;
         const int HotPlugMatchAny = -1;
-        var supported = libusb_has_capability(HotPlugCapability) != 0;
+        var supported = libusb_has_capability((uint)LibUsbCapability.HasHotplug) != 0;
         if (!supported)
         {
             _logger.LogDebug("Hotplug not supported or unimplemented on this platform.");


### PR DESCRIPTION
Fixes issue causing RegisterHotplug to fail on macOS
- Uses correct value when checking Hotplug capability
- Introduces a LibUsbCapability enum that defines the allowed capability values