### PR TITLE
Remove redundant TryAdd and dead code that follows

### DIFF
--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -112,25 +112,10 @@ public sealed class UsbDevice : IUsbDevice
                 );
             }
             var usbInterface = new UsbInterface(_loggerFactory, Handle, descriptor);
-            if (_claimedInterfaces.TryAdd(descriptor.InterfaceNumber, usbInterface))
-            {
-                _logger.LogDebug("USB interface {UsbInterface} claimed.", usbInterface);
-                return usbInterface;
-            }
-            // If add claimed interface fails, release the interface immediately
-            var releaseResult = libusb_release_interface(Handle, descriptor.InterfaceNumber);
-            if (releaseResult != 0)
-            {
-                _logger.LogError(
-                    "Failed to release USB interface {UsbInterface}. {ErrorMessage}",
-                    descriptor,
-                    ((LibUsbResult)releaseResult).GetMessage()
-                );
-            }
-            throw new LibUsbException(
-                "Failed to add claimed USB interface to list of claimed interfaces.",
-                LibUsbResult.ManagedError
-            );
+            // No need to check if already added, checked in TryGetValue above
+            _ = _claimedInterfaces.TryAdd(descriptor.InterfaceNumber, usbInterface);
+            _logger.LogDebug("USB interface {UsbInterface} claimed.", usbInterface);
+            return usbInterface;
         }
         finally
         {

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -113,7 +113,7 @@ public sealed class UsbDevice : IUsbDevice
             }
             var usbInterface = new UsbInterface(_loggerFactory, Handle, descriptor);
             // No need to check if already added, checked in TryGetValue above
-            _ = _claimedInterfaces.TryAdd(descriptor.InterfaceNumber, usbInterface);
+            _claimedInterfaces[descriptor.InterfaceNumber] = usbInterface;
             _logger.LogDebug("USB interface {UsbInterface} claimed.", usbInterface);
             return usbInterface;
         }


### PR DESCRIPTION
Fix issue discovered by @superstian during code review. Remove redundant TryAdd and dead code that follows. TryAdd is redundant, presence of claimed interface is already tested in the TryGetValue above. The execution of the TryGetValue and TryAdd are within the scope of the same write lock.