### PR TITLE
Remove LibUsb constructor logger factory default

### DIFF
--- a/src/LibUsbSharp/LibUsb.cs
+++ b/src/LibUsbSharp/LibUsb.cs
@@ -37,7 +37,10 @@ public sealed class LibUsb : ILibUsb
     /// Creates the LibUsb wrapper.
     /// NOTE: Call Initialize() before enumerating or opening devices.
     /// </summary>
-    public LibUsb(ILoggerFactory? loggerFactory = default)
+    /// <param name="loggerFactory">
+    /// Optional logger factory. Without this libusb logs are piped to dev/null.
+    /// </param>
+    public LibUsb(ILoggerFactory? loggerFactory)
     {
         _loggerFactory = loggerFactory ?? new NullLoggerFactory();
         _logger = _loggerFactory.CreateLogger<LibUsb>();

--- a/src/LibUsbSharp/LibUsb.cs
+++ b/src/LibUsbSharp/LibUsb.cs
@@ -38,7 +38,7 @@ public sealed class LibUsb : ILibUsb
     /// NOTE: Call Initialize() before enumerating or opening devices.
     /// </summary>
     /// <param name="loggerFactory">
-    /// Optional logger factory. Without this libusb logs are piped to dev/null.
+    /// Logger factory for libusb logging. If null, logging is disabled.
     /// </param>
     public LibUsb(ILoggerFactory? loggerFactory)
     {

--- a/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
@@ -18,7 +18,7 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
     {
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_a_vendor_class_USB_device>();
-        _libUsb = new LibUsb();
+        _libUsb = new LibUsb(_loggerFactory);
         _libUsb.Initialize(LogLevel.Information);
         _deviceSource = new TestDeviceSource(_logger, _libUsb);
         _deviceSource.SetPreferredVendorId(0x2BD9);

--- a/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
@@ -18,7 +18,7 @@ public sealed class Given_any_USB_device : IDisposable
     {
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_any_USB_device>();
-        _libUsb = new LibUsb();
+        _libUsb = new LibUsb(_loggerFactory);
         _libUsb.Initialize(LogLevel.Information);
         _deviceSource = new TestDeviceSource(_logger, _libUsb);
         _deviceSource.SetPreferredVendorId(0x2BD9);

--- a/tests/LibUsbSharp.Tests/Given_no_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_no_USB_device.cs
@@ -9,12 +9,10 @@ namespace LibUsbSharp.Tests;
 public sealed class Given_no_USB_device : IDisposable
 {
     private readonly ILoggerFactory _loggerFactory;
-    private readonly ILogger<Given_no_USB_device> _logger;
 
     public Given_no_USB_device(ITestOutputHelper output)
     {
         _loggerFactory = new TestLoggerFactory(output);
-        _logger = _loggerFactory.CreateLogger<Given_no_USB_device>();
     }
 
     [Fact]
@@ -27,7 +25,7 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void GetDeviceList_throws_when_called_without_Initialize()
     {
-        using var libUsb = new LibUsb();
+        using var libUsb = new LibUsb(_loggerFactory);
         var act = () => libUsb.GetDeviceList();
         act.Should().Throw<InvalidOperationException>();
     }
@@ -35,7 +33,7 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void GetDeviceList_throws_when_called_after_Dispose()
     {
-        using var libUsb = new LibUsb();
+        using var libUsb = new LibUsb(_loggerFactory);
         libUsb.Initialize(LogLevel.Information);
         libUsb.Dispose();
         var act = () => libUsb.GetDeviceList();
@@ -49,7 +47,7 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var libUsb = new LibUsb();
+        using var libUsb = new LibUsb(_loggerFactory);
         var act = () => libUsb.RegisterHotplug(vendorId: 0x2BD9);
         act.Should().Throw<InvalidOperationException>();
     }
@@ -61,7 +59,7 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var libUsb = new LibUsb();
+        using var libUsb = new LibUsb(_loggerFactory);
         libUsb.Initialize(LogLevel.Information);
         var success = libUsb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeTrue();
@@ -74,7 +72,7 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var libUsb = new LibUsb();
+        using var libUsb = new LibUsb(_loggerFactory);
         libUsb.Initialize(LogLevel.Information);
         var success = libUsb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeFalse();


### PR DESCRIPTION
null value. The consumer should make an active choice whether or not to provide a logger factory.