### PR TITLE
Fix lock reentry issue in UsbInterface.Dispose

### DIFF
--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -196,8 +196,7 @@ public sealed class UsbDevice : IUsbDevice
         {
 #if DEBUG
             throw;
-#endif
-#if !DEBUG
+#else
             _logger.LogWarning("UsbDevice already disposed.");
             return;
 #endif

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -18,6 +18,7 @@ public sealed class UsbDevice : IUsbDevice
     private readonly ConcurrentDictionary<byte, string> _descriptorCache = new();
     private readonly object _cacheLock = new();
     private readonly RundownGuard _rundownGuard = new();
+    private readonly object _interfaceLock = new();
 
     internal nint Handle { get; init; }
 
@@ -101,26 +102,29 @@ public sealed class UsbDevice : IUsbDevice
     {
         using var token = _rundownGuard.AcquireExclusiveToken();
 
-        if (_claimedInterfaces.TryGetValue(descriptor.InterfaceNumber, out var existing))
+        lock (_interfaceLock)
         {
-            throw new ArgumentException($"USB interface {existing} already claimed.");
-        }
+            if (_claimedInterfaces.TryGetValue(descriptor.InterfaceNumber, out var existing))
+            {
+                throw new ArgumentException($"USB interface {existing} already claimed.");
+            }
 
-        // TODO: libusb_set_auto_detach_kernel_driver on Linux?
-        var claimResult = libusb_claim_interface(Handle, descriptor.InterfaceNumber);
-        if (claimResult != 0)
-        {
-            throw LibUsbException.FromError(
-                claimResult,
-                $"Failed to claim USB interface {descriptor}."
-            );
-        }
+            // TODO: libusb_set_auto_detach_kernel_driver on Linux?
+            var claimResult = libusb_claim_interface(Handle, descriptor.InterfaceNumber);
+            if (claimResult != 0)
+            {
+                throw LibUsbException.FromError(
+                    claimResult,
+                    $"Failed to claim USB interface {descriptor}."
+                );
+            }
 
-        var usbInterface = new UsbInterface(_loggerFactory, this, descriptor);
-        // No need to check if already added, checked in TryGetValue above
-        _claimedInterfaces[descriptor.InterfaceNumber] = usbInterface;
-        _logger.LogDebug("USB interface {UsbInterface} claimed.", usbInterface);
-        return usbInterface;
+            var usbInterface = new UsbInterface(_loggerFactory, this, descriptor);
+            // No need to check if already added, checked in TryGetValue above
+            _claimedInterfaces[descriptor.InterfaceNumber] = usbInterface;
+            _logger.LogDebug("USB interface {UsbInterface} claimed.", usbInterface);
+            return usbInterface;
+        }
     }
 
     /// <summary>
@@ -137,34 +141,35 @@ public sealed class UsbDevice : IUsbDevice
     /// </exception>
     internal void ReleaseInterface(byte interfaceNumber)
     {
-        using var token = _rundownGuard.AcquireExclusiveToken();
+        lock (_interfaceLock)
+        {
+            if (!_claimedInterfaces.TryGetValue(interfaceNumber, out var usbInterface))
+            {
+                throw new InvalidOperationException(
+                    $"USB interface #{interfaceNumber} not found in list of claimed interfaces."
+                );
+            }
 
-        if (!_claimedInterfaces.TryGetValue(interfaceNumber, out var usbInterface))
-        {
-            throw new InvalidOperationException(
-                $"USB interface #{interfaceNumber} not found in list of claimed interfaces."
-            );
-        }
+            var releaseResult = libusb_release_interface(Handle, interfaceNumber);
+            if (releaseResult != 0)
+            {
+                throw LibUsbException.FromError(
+                    releaseResult,
+                    $"Failed to release USB interface {usbInterface}."
+                );
+            }
 
-        var releaseResult = libusb_release_interface(Handle, interfaceNumber);
-        if (releaseResult != 0)
-        {
-            throw LibUsbException.FromError(
-                releaseResult,
-                $"Failed to release USB interface {usbInterface}."
-            );
-        }
-
-        if (_claimedInterfaces.TryRemove(interfaceNumber, out var _))
-        {
-            _logger.LogDebug("USB interface {UsbInterface} released.", usbInterface);
-        }
-        else
-        {
-            _logger.LogError(
-                "Failed to remove released USB interface {UsbInterface} from list of claimed interfaces.",
-                usbInterface
-            );
+            if (_claimedInterfaces.TryRemove(interfaceNumber, out var _))
+            {
+                _logger.LogDebug("USB interface {UsbInterface} released.", usbInterface);
+            }
+            else
+            {
+                _logger.LogError(
+                    "Failed to remove released USB interface {UsbInterface} from list of claimed interfaces.",
+                    usbInterface
+                );
+            }
         }
     }
 
@@ -203,13 +208,15 @@ public sealed class UsbDevice : IUsbDevice
         }
         try
         {
-            // Release all claimed USB interfaces
-            foreach (var usbInterface in _claimedInterfaces.Values)
+            lock (_interfaceLock)
             {
-                usbInterface.Dispose();
+                // Release all claimed USB interfaces
+                foreach (var usbInterface in _claimedInterfaces.Values)
+                {
+                    usbInterface.Dispose();
+                }
+                _claimedInterfaces.Clear();
             }
-            _claimedInterfaces.Clear();
-
             // Ask LibUsb to close device and remove it from list of open devices
             _libUsb.CloseDevice(Descriptor.DeviceKey, Handle);
             _logger.LogInformation("UsbDevice '{DeviceKey}' disposed.", Descriptor.DeviceKey);

--- a/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
@@ -61,6 +61,17 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
         endpoint!.MaxPacketSize.Should().BePositive();
     }
 
+    [SkippableFact]
+    public void Open_interfaces_are_auto_disposed_when_UsbDevice_is_disposed()
+    {
+        // Open device and leave it open
+        var device = _deviceSource.OpenUsbDeviceOrSkip();
+        // Claim interface without disposing it
+        _ = device.ClaimInterface(UsbClass.VendorSpecific);
+        // Dispose device
+        device.Dispose();
+    }
+
     public void Dispose()
     {
         _libUsb.Dispose();

--- a/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
@@ -112,11 +112,16 @@ public sealed class Given_any_USB_device : IDisposable
         // Dispose LibUsb to trigger auto disposal of devices
         _libUsb.Dispose();
         // Attempt to get serial, the device should be auto disposed at this point
-        var act = () => device.GetSerialNumber();
-        act.Should().Throw<ObjectDisposedException>();
-        // Calling dispose again is OK
-        var act2 = () => device.Dispose();
-        act2.Should().NotThrow();
+        var getSerialAct = () => device.GetSerialNumber();
+        getSerialAct.Should().Throw<ObjectDisposedException>();
+        var disposeAct = () => device.Dispose();
+#if DEBUG
+        // Calling dispose in debug throws exception
+        disposeAct.Should().Throw<ObjectDisposedException>();
+#else
+        // Calling dispose again in release only logs warning
+        disposeAct.Should().NotThrow();
+#endif
     }
 
     public void Dispose()


### PR DESCRIPTION
Fix lock reentry issue in UsbInterface.Dispose that blocks anyone from getting the guard once
rundown has started. The issue was fixed by adding a separate lock to
protect interface claim and release operations.