### PR TITLE
Implement UsbDevice ControlRequest read/write

### DIFF
--- a/src/LibUsbSharp/ControlRequestStandard.cs
+++ b/src/LibUsbSharp/ControlRequestStandard.cs
@@ -1,0 +1,28 @@
+﻿namespace LibUsbSharp;
+
+/// <summary>
+/// Standard control requests (USB spec Chapter 9.4) and USB 3.x additions.
+/// Use in combination with ControlRead/ControlWrite <see cref="ControlRequestType.Standard"/>.
+/// </summary>
+public enum ControlRequestStandard : byte
+{
+    GetStatus = 0x00,
+    ClearFeature = 0x01,
+
+    // 0x02 reserved
+    SetFeature = 0x03,
+
+    // 0x04 reserved
+    SetAddress = 0x05,
+    GetDescriptor = 0x06,
+    SetDescriptor = 0x07,
+    GetConfiguration = 0x08,
+    SetConfiguration = 0x09,
+    GetInterface = 0x0A,
+    SetInterface = 0x0B,
+    SynchFrame = 0x0C,
+
+    // USB 3.x (SuperSpeed) additions:
+    SetSel = 0x30,
+    SetIsochDelay = 0x31,
+}

--- a/src/LibUsbSharp/ControlRequestType.cs
+++ b/src/LibUsbSharp/ControlRequestType.cs
@@ -6,8 +6,8 @@
 /// </summary>
 internal enum ControlRequestDirection : byte
 {
-    Out = 0b00000000,
-    In = 0b10000000, // 0x80
+    Out = 0b0,
+    In = 0b1,
 }
 
 public enum ControlRequestType : byte
@@ -15,17 +15,17 @@ public enum ControlRequestType : byte
     /// <summary>
     /// Request value per the standard control requests defined in the USB spec.
     /// </summary>
-    Standard = 0b00000000,
+    Standard = 0b00,
 
     /// <summary>
     /// Request values defined in the individual USB class spec.
     /// </summary>
-    Class = 0b00100000, // 0x20
+    Class = 0b01,
 
     /// <summary>
     /// Request values defined by device vendor.
     /// </summary>
-    Vendor = 0b01000000, // 0x40
+    Vendor = 0b10,
 }
 
 public enum ControlRequestRecipient : byte
@@ -33,20 +33,20 @@ public enum ControlRequestRecipient : byte
     /// <summary>
     /// The request affects the whole device.
     /// </summary>
-    Device = 0b00000000,
+    Device = 0b00000,
 
     /// <summary>
     /// The request targets a specific interface.
     /// </summary>
-    Interface = 0b00000001, // 0x01
+    Interface = 0b00001, // 0x01
 
     /// <summary>
     /// The request targets a specific endpoint.
     /// </summary>
-    Endpoint = 0b00000010, // 0x02
+    Endpoint = 0b00010, // 0x02
 
     /// <summary>
     /// The request targets "other" elements defined by a class spec (not an interface or endpoint).
     /// </summary>
-    Other = 0b00000011, // 0x03
+    Other = 0b00011, // 0x03
 }

--- a/src/LibUsbSharp/ControlRequestType.cs
+++ b/src/LibUsbSharp/ControlRequestType.cs
@@ -1,0 +1,52 @@
+﻿namespace LibUsbSharp;
+
+/// <summary>
+/// This enum represents the control request direction. The enum value should be bitwise combined
+/// with ControlRequestType and ControlRequestRecipient, to form the full ControlRequest type.
+/// </summary>
+internal enum ControlRequestDirection : byte
+{
+    Out = 0b00000000,
+    In = 0b10000000, // 0x80
+}
+
+public enum ControlRequestType : byte
+{
+    /// <summary>
+    /// Request value per the standard control requests defined in the USB spec.
+    /// </summary>
+    Standard = 0b00000000,
+
+    /// <summary>
+    /// Request values defined in the individual USB class spec.
+    /// </summary>
+    Class = 0b00100000, // 0x20
+
+    /// <summary>
+    /// Request values defined by device vendor.
+    /// </summary>
+    Vendor = 0b01000000, // 0x40
+}
+
+public enum ControlRequestRecipient : byte
+{
+    /// <summary>
+    /// The request affects the whole device.
+    /// </summary>
+    Device = 0b00000000,
+
+    /// <summary>
+    /// The request targets a specific interface.
+    /// </summary>
+    Interface = 0b00000001, // 0x01
+
+    /// <summary>
+    /// The request targets a specific endpoint.
+    /// </summary>
+    Endpoint = 0b00000010, // 0x02
+
+    /// <summary>
+    /// The request targets "other" elements defined by a class spec (not an interface or endpoint).
+    /// </summary>
+    Other = 0b00000011, // 0x03
+}

--- a/src/LibUsbSharp/IUsbDevice.cs
+++ b/src/LibUsbSharp/IUsbDevice.cs
@@ -66,7 +66,7 @@ public interface IUsbDevice : IDisposable
     /// Interrupted = The read operation was canceled.<br />
     /// NotSupported = The transfer flags are not supported by the operating system.<br />
     /// </returns>
-    LibUsbResult ControlRequestRead(
+    LibUsbResult ControlRead(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,
@@ -100,7 +100,7 @@ public interface IUsbDevice : IDisposable
     /// Interrupted = The write operation was canceled.<br />
     /// NotSupported = The transfer flags are not supported by the operating system.<br />
     /// </returns>
-    LibUsbResult ControlRequestWrite(
+    LibUsbResult ControlWrite(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,

--- a/src/LibUsbSharp/IUsbDevice.cs
+++ b/src/LibUsbSharp/IUsbDevice.cs
@@ -44,6 +44,74 @@ public interface IUsbDevice : IDisposable
     string ReadStringDescriptor(byte descriptorIndex);
 
     /// <summary>
+    /// Send a ControlRead request. Data is read Device -> Host.
+    /// </summary>
+    /// <param name="recipient">The recipient of the control request</param>
+    /// <param name="type">The control request type; standard, class or vendor</param>
+    /// <param name="request">The USB standard spec, class spec or vendor defined request</param>
+    /// <param name="value">The value field for the setup packet</param>
+    /// <param name="index">The index field for the setup packet</param>
+    /// <param name="destination">A destination span for read bytes</param>
+    /// <param name="bytesRead">The number of bytes read</param>
+    /// <param name="timeout">Timeout before giving up due to no response being received</param>
+    /// <exception cref="ArgumentException">Thrown when the destination buffer is too large.</exception>
+    /// <returns>
+    /// Success = The read operation completed successfully.<br />
+    /// IO = The read operation failed.<br />
+    /// InvalidParameter = Transfer size is larger than OS or hardware can support.<br />
+    /// NoDevice = The device has been disconnected.<br />
+    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.<br />
+    /// Timeout = The read operation timed out.<br />
+    /// Overflow = The device sent more data than expected.<br />
+    /// Interrupted = The read operation was canceled.<br />
+    /// NotSupported = The transfer flags are not supported by the operating system.<br />
+    /// </returns>
+    LibUsbResult ControlRead(
+        ControlRequestRecipient recipient,
+        ControlRequestType type,
+        byte request,
+        ushort value,
+        ushort index,
+        Span<byte> destination,
+        out ushort bytesRead,
+        int timeout = Timeout.Infinite
+    );
+
+    /// <summary>
+    /// Send a ControlWrite request. Data is written Host -> Device.
+    /// </summary>
+    /// <param name="recipient">The recipient of the control request</param>
+    /// <param name="type">The control request type; standard, class or vendor</param>
+    /// <param name="request">The USB standard spec, class spec or vendor defined request</param>
+    /// <param name="value">The value field for the setup packet</param>
+    /// <param name="index">The index field for the setup packet</param>
+    /// <param name="source">The payload to send to the device (max. 65.535 bytes)</param>
+    /// <param name="timeout">Timeout before giving up due to no response being received</param>
+    /// <param name="bytesWritten">The actual number of bytes written to the device</param>
+    /// <exception cref="ArgumentException">Thrown when the source payload is too large.</exception>
+    /// <returns>
+    /// Success = The write operation completed successfully.<br />
+    /// IO = The write operation failed.<br />
+    /// InvalidParameter = Transfer size is larger than OS or hardware can support.<br />
+    /// NoDevice = The device has been disconnected.<br />
+    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.<br />
+    /// Timeout = The write operation timed out.<br />
+    /// Overflow = The host sent more data than expected.<br />
+    /// Interrupted = The write operation was canceled.<br />
+    /// NotSupported = The transfer flags are not supported by the operating system.<br />
+    /// </returns>
+    LibUsbResult ControlWrite(
+        ControlRequestRecipient recipient,
+        ControlRequestType type,
+        byte request,
+        ushort value,
+        ushort index,
+        ReadOnlySpan<byte> source,
+        out int bytesWritten,
+        int timeout = Timeout.Infinite
+    );
+
+    /// <summary>
     /// Claim a USB interface. The interface will be auto-released when the device is disposed.
     /// </summary>
     /// <exception cref="ArgumentException">

--- a/src/LibUsbSharp/IUsbDevice.cs
+++ b/src/LibUsbSharp/IUsbDevice.cs
@@ -66,7 +66,7 @@ public interface IUsbDevice : IDisposable
     /// Interrupted = The read operation was canceled.<br />
     /// NotSupported = The transfer flags are not supported by the operating system.<br />
     /// </returns>
-    LibUsbResult ControlRead(
+    LibUsbResult ControlRequestRead(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,
@@ -100,7 +100,7 @@ public interface IUsbDevice : IDisposable
     /// Interrupted = The write operation was canceled.<br />
     /// NotSupported = The transfer flags are not supported by the operating system.<br />
     /// </returns>
-    LibUsbResult ControlWrite(
+    LibUsbResult ControlRequestWrite(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,

--- a/src/LibUsbSharp/Internal/Transfer/LibUsbControlRequestSetup.cs
+++ b/src/LibUsbSharp/Internal/Transfer/LibUsbControlRequestSetup.cs
@@ -18,7 +18,7 @@ namespace LibUsbSharp.Internal.Transfer;
 /// <param name="Length">Read/write payload length or 0 when request has no payload.</param>
 // Use pack 1; the fields should be layed out in memory without padding
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
-internal record struct LibUsbControlSetup(
+internal record struct LibUsbControlRequestSetup(
     byte RequestType,
     byte Request,
     ushort Value,
@@ -31,29 +31,29 @@ internal record struct LibUsbControlSetup(
     /// <summary>
     /// Create an 8 byte read request LibUsbControlSetup struct from given parameters.
     /// </summary>
-    internal static LibUsbControlSetup ReadRequest(
+    internal static LibUsbControlRequestSetup Read(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,
         ushort value,
         ushort index,
         ushort length
-    ) => AnyRequest(ControlRequestDirection.In, recipient, type, request, value, index, length);
+    ) => Packet(ControlRequestDirection.In, recipient, type, request, value, index, length);
 
     /// <summary>
     /// Create an 8 byte write request LibUsbControlSetup struct from given parameters.
     /// </summary>
-    internal static LibUsbControlSetup WriteRequest(
+    internal static LibUsbControlRequestSetup Write(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,
         ushort value,
         ushort index,
         ushort length
-    ) => AnyRequest(ControlRequestDirection.Out, recipient, type, request, value, index, length);
+    ) => Packet(ControlRequestDirection.Out, recipient, type, request, value, index, length);
 
     /// Create an 8 byte LibUsbControlSetup struct from given parameters.
-    private static LibUsbControlSetup AnyRequest(
+    private static LibUsbControlRequestSetup Packet(
         ControlRequestDirection direction,
         ControlRequestRecipient recipient,
         ControlRequestType type,

--- a/src/LibUsbSharp/Internal/Transfer/LibUsbControlRequestSetup.cs
+++ b/src/LibUsbSharp/Internal/Transfer/LibUsbControlRequestSetup.cs
@@ -63,7 +63,7 @@ internal record struct LibUsbControlRequestSetup(
         ushort length
     ) =>
         new(
-            RequestType: (byte)((byte)direction | (byte)recipient | (byte)type),
+            RequestType: (byte)((byte)direction << 7 | (byte)type << 5 | (byte)recipient),
             Request: request,
             Value: value,
             Index: index,

--- a/src/LibUsbSharp/Internal/Transfer/LibUsbControlRequestSetup.cs
+++ b/src/LibUsbSharp/Internal/Transfer/LibUsbControlRequestSetup.cs
@@ -3,7 +3,7 @@
 namespace LibUsbSharp.Internal.Transfer;
 
 /// <summary>
-/// A LibUsbControlSetup struct for Control Transfer input/read and output/wrote requests.
+/// A LibUsbControlRequestSetup struct for Control Transfer input/read and output/wrote requests.
 /// The struct forms the 8 byte header/setup packet. It may or may not be followed by a payload.
 /// </summary>
 /// <param name="RequestType">
@@ -29,7 +29,7 @@ internal record struct LibUsbControlRequestSetup(
     internal const int Size = 8; // Setup packet is exactly 8 bytes without padding
 
     /// <summary>
-    /// Create an 8 byte read request LibUsbControlSetup struct from given parameters.
+    /// Create an 8 byte read request LibUsbControlRequestSetup struct from given parameters.
     /// </summary>
     internal static LibUsbControlRequestSetup Read(
         ControlRequestRecipient recipient,
@@ -41,7 +41,7 @@ internal record struct LibUsbControlRequestSetup(
     ) => Packet(ControlRequestDirection.In, recipient, type, request, value, index, length);
 
     /// <summary>
-    /// Create an 8 byte write request LibUsbControlSetup struct from given parameters.
+    /// Create an 8 byte write request LibUsbControlRequestSetup struct from given parameters.
     /// </summary>
     internal static LibUsbControlRequestSetup Write(
         ControlRequestRecipient recipient,
@@ -52,7 +52,7 @@ internal record struct LibUsbControlRequestSetup(
         ushort length
     ) => Packet(ControlRequestDirection.Out, recipient, type, request, value, index, length);
 
-    /// Create an 8 byte LibUsbControlSetup struct from given parameters.
+    /// Create an 8 byte LibUsbControlRequestSetup struct from given parameters.
     private static LibUsbControlRequestSetup Packet(
         ControlRequestDirection direction,
         ControlRequestRecipient recipient,

--- a/src/LibUsbSharp/Internal/Transfer/LibUsbControlSetup.cs
+++ b/src/LibUsbSharp/Internal/Transfer/LibUsbControlSetup.cs
@@ -1,0 +1,85 @@
+﻿using System.Runtime.InteropServices;
+
+namespace LibUsbSharp.Internal.Transfer;
+
+/// <summary>
+/// An 8 byte LibUsbControlSetup struct.
+/// </summary>
+/// <param name="RequestType">
+/// Bit 7 (Direction)     | 0 = Host -> Device (OUT) 1 = Device -> Host (IN).<br />
+/// Bits 6..5 (Type)      | 00 = Standard, 01 = Class, 10 = Vendor, 11 = Reserved.<br />
+/// Bits 4..0 (Recipient) | 00000 = Device, 00001 = Interface, 00010 = Endpoint, 00011 = Other,
+/// 00100-11111 = Reserved.
+/// </param>
+/// <param name="Request">The USB standard spec, class spec or vendor defined request</param>
+/// <param name="Value">The value field for the setup packet</param>
+/// <param name="Index">The index field for the setup packet</param>
+/// <param name="Length">Read/write payload length or 0 when request has no payload.</param>
+// Use pack 1; the fields should be layed out in memory without padding
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+internal record struct LibUsbControlSetup(
+    byte RequestType,
+    byte Request,
+    ushort Value,
+    ushort Index,
+    ushort Length
+)
+{
+    internal const int Size = 8; // Setup packet is exactly 8 bytes without padding
+
+    /// <summary>
+    /// Create an 8 byte read request LibUsbControlSetup struct from given parameters.
+    /// </summary>
+    internal static LibUsbControlSetup ReadRequest(
+        ControlRequestRecipient recipient,
+        ControlRequestType type,
+        byte request,
+        ushort value,
+        ushort index,
+        ushort length
+    ) => AnyRequest(ControlRequestDirection.In, recipient, type, request, value, index, length);
+
+    /// <summary>
+    /// Create an 8 byte write request LibUsbControlSetup struct from given parameters.
+    /// </summary>
+    internal static LibUsbControlSetup WriteRequest(
+        ControlRequestRecipient recipient,
+        ControlRequestType type,
+        byte request,
+        ushort value,
+        ushort index,
+        ushort length
+    ) => AnyRequest(ControlRequestDirection.Out, recipient, type, request, value, index, length);
+
+    /// Create an 8 byte LibUsbControlSetup struct from given parameters.
+    private static LibUsbControlSetup AnyRequest(
+        ControlRequestDirection direction,
+        ControlRequestRecipient recipient,
+        ControlRequestType type,
+        byte request,
+        ushort value,
+        ushort index,
+        ushort length
+    ) =>
+        new(
+            RequestType: (byte)((byte)direction | (byte)recipient | (byte)type),
+            Request: request,
+            Value: value,
+            Index: index,
+            Length: length
+        );
+
+    /// <summary>
+    /// Create a byte array that consists of the setup bytes + space for given Length of data.
+    /// </summary>
+    internal byte[] CreateBuffer()
+    {
+        var buffer = new byte[Size + Length];
+        // This writes with host endianness. libusb expects little-endian fields.
+        // On mainstream platforms (.NET on x86/x64/ARM LE) this should be fine.
+#pragma warning disable CS9191 // .NET6, silence warning. The 'ref' modifier for an argument corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+        MemoryMarshal.Write(buffer, ref this);
+#pragma warning restore CS9191 // .NET6, silence warning. The 'ref' modifier for an argument corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+        return buffer;
+    }
+}

--- a/src/LibUsbSharp/Internal/Transfer/LibUsbControlSetup.cs
+++ b/src/LibUsbSharp/Internal/Transfer/LibUsbControlSetup.cs
@@ -3,7 +3,8 @@
 namespace LibUsbSharp.Internal.Transfer;
 
 /// <summary>
-/// An 8 byte LibUsbControlSetup struct.
+/// A LibUsbControlSetup struct for Control Transfer input/read and output/wrote requests.
+/// The struct forms the 8 byte header/setup packet. It may or may not be followed by a payload.
 /// </summary>
 /// <param name="RequestType">
 /// Bit 7 (Direction)     | 0 = Host -> Device (OUT) 1 = Device -> Host (IN).<br />

--- a/src/LibUsbSharp/LibUsbSharp.csproj
+++ b/src/LibUsbSharp/LibUsbSharp.csproj
@@ -25,6 +25,9 @@
         <AnalysisLevel>latest-recommended</AnalysisLevel>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="LibUsbSharp.Tests" />
+    </ItemGroup>
     <ItemGroup Label="Include Native Libraries">
         <!-- linux-arm64 - NOTE: Rely on included libusb (apt-get) on Linux -->
         <!-- linux-x64 - NOTE: Rely on included libusb (apt-get) on Linux -->

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -120,6 +120,9 @@ public sealed class UsbDevice : IUsbDevice
                 $"Destination buffer must be less than {ushort.MaxValue} bytes."
             );
         }
+
+        using var token = _rundownGuard.AcquireSharedToken();
+
         var length = (ushort)destination.Length;
         var setup = LibUsbControlSetup.ReadRequest(recipient, type, request, value, index, length);
         var buffer = setup.CreateBuffer();
@@ -172,6 +175,8 @@ public sealed class UsbDevice : IUsbDevice
                 $"Payload must be less than {ushort.MaxValue} bytes."
             );
         }
+
+        using var token = _rundownGuard.AcquireSharedToken();
 
         var length = (ushort)source.Length;
         var setup = LibUsbControlSetup.WriteRequest(recipient, type, request, value, index, length);

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -102,7 +102,7 @@ public sealed class UsbDevice : IUsbDevice
     }
 
     /// <inheritdoc />
-    public LibUsbResult ControlRead(
+    public LibUsbResult ControlRequestRead(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,
@@ -157,7 +157,7 @@ public sealed class UsbDevice : IUsbDevice
     }
 
     /// <inheritdoc />
-    public LibUsbResult ControlWrite(
+    public LibUsbResult ControlRequestWrite(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -10,7 +10,7 @@ namespace LibUsbSharp;
 
 public sealed class UsbDevice : IUsbDevice
 {
-    private const byte ControTransferEndpoint = 0x00;
+    private const byte ControlRequestEndpoint = 0x00;
 
     private readonly LibUsb _libUsb;
     private readonly nint _context;
@@ -134,7 +134,7 @@ public sealed class UsbDevice : IUsbDevice
                 _logger,
                 Handle,
                 LibUsbTransferType.Control,
-                ControTransferEndpoint,
+                ControlRequestEndpoint,
                 bufferHandle,
                 buffer.Length,
                 timeout > 0 ? (uint)timeout : 0,
@@ -193,7 +193,7 @@ public sealed class UsbDevice : IUsbDevice
                 _logger,
                 Handle,
                 LibUsbTransferType.Control,
-                ControTransferEndpoint,
+                ControlRequestEndpoint,
                 bufferHandle,
                 buffer.Length,
                 timeout > 0 ? (uint)timeout : 0,

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -125,7 +125,7 @@ public sealed class UsbDevice : IUsbDevice
         using var token = _rundownGuard.AcquireSharedToken();
 
         var length = (ushort)destination.Length;
-        var setup = LibUsbControlSetup.ReadRequest(recipient, type, request, value, index, length);
+        var setup = LibUsbControlRequestSetup.Read(recipient, type, request, value, index, length);
         var buffer = setup.CreateBuffer();
         var bufferHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
         try
@@ -147,7 +147,7 @@ public sealed class UsbDevice : IUsbDevice
                 destination = Array.Empty<byte>();
                 return result;
             }
-            buffer.AsSpan(LibUsbControlSetup.Size, bytesRead).CopyTo(destination);
+            buffer.AsSpan(LibUsbControlRequestSetup.Size, bytesRead).CopyTo(destination);
             return result;
         }
         finally
@@ -180,11 +180,11 @@ public sealed class UsbDevice : IUsbDevice
         using var token = _rundownGuard.AcquireSharedToken();
 
         var length = (ushort)source.Length;
-        var setup = LibUsbControlSetup.WriteRequest(recipient, type, request, value, index, length);
+        var setup = LibUsbControlRequestSetup.Write(recipient, type, request, value, index, length);
         var buffer = setup.CreateBuffer();
         if (length > 0)
         {
-            source.CopyTo(buffer.AsSpan(LibUsbControlSetup.Size, length));
+            source.CopyTo(buffer.AsSpan(LibUsbControlRequestSetup.Size, length));
         }
         var bufferHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
         try

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -102,7 +102,7 @@ public sealed class UsbDevice : IUsbDevice
     }
 
     /// <inheritdoc />
-    public LibUsbResult ControlRequestRead(
+    public LibUsbResult ControlRead(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,
@@ -157,7 +157,7 @@ public sealed class UsbDevice : IUsbDevice
     }
 
     /// <inheritdoc />
-    public LibUsbResult ControlRequestWrite(
+    public LibUsbResult ControlWrite(
         ControlRequestRecipient recipient,
         ControlRequestType type,
         byte request,

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -10,7 +10,7 @@ namespace LibUsbSharp;
 
 public sealed class UsbDevice : IUsbDevice
 {
-    private const byte ControlEndpoint = 0x00;
+    private const byte ControTransferEndpoint = 0x00;
 
     private readonly LibUsb _libUsb;
     private readonly nint _context;
@@ -134,7 +134,7 @@ public sealed class UsbDevice : IUsbDevice
                 _logger,
                 Handle,
                 LibUsbTransferType.Control,
-                ControlEndpoint,
+                ControTransferEndpoint,
                 bufferHandle,
                 buffer.Length,
                 timeout > 0 ? (uint)timeout : 0,
@@ -193,7 +193,7 @@ public sealed class UsbDevice : IUsbDevice
                 _logger,
                 Handle,
                 LibUsbTransferType.Control,
-                ControlEndpoint,
+                ControTransferEndpoint,
                 bufferHandle,
                 buffer.Length,
                 timeout > 0 ? (uint)timeout : 0,

--- a/src/LibUsbSharp/UsbDeviceExtension.cs
+++ b/src/LibUsbSharp/UsbDeviceExtension.cs
@@ -4,6 +4,48 @@ namespace LibUsbSharp;
 
 public static class UsbDeviceExtension
 {
+    public static LibUsbResult ControlRead(
+        this IUsbDevice device,
+        ControlRequestRecipient recipient,
+        ControlRequestStandard request,
+        ushort value,
+        ushort index,
+        Span<byte> destination,
+        out ushort bytesRead,
+        int timeout = Timeout.Infinite
+    ) =>
+        device.ControlRead(
+            recipient,
+            ControlRequestType.Standard,
+            (byte)request,
+            value,
+            index,
+            destination,
+            out bytesRead,
+            timeout
+        );
+
+    public static LibUsbResult ControlWrite(
+        this IUsbDevice device,
+        ControlRequestRecipient recipient,
+        ControlRequestStandard request,
+        ushort value,
+        ushort index,
+        ReadOnlySpan<byte> source,
+        out int bytesWritten,
+        int timeout = Timeout.Infinite
+    ) =>
+        device.ControlWrite(
+            recipient,
+            ControlRequestType.Standard,
+            (byte)request,
+            value,
+            index,
+            source,
+            out bytesWritten,
+            timeout
+        );
+
     /// <summary>
     /// Claim a USB interface. The interface will be auto-released when the device is disposed.
     /// NOTE: When more than one matching interface is found, the first is selected and claimed.

--- a/src/LibUsbSharp/UsbDeviceExtension.cs
+++ b/src/LibUsbSharp/UsbDeviceExtension.cs
@@ -4,7 +4,7 @@ namespace LibUsbSharp;
 
 public static class UsbDeviceExtension
 {
-    public static LibUsbResult ControlRead(
+    public static LibUsbResult ControlRequestRead(
         this IUsbDevice device,
         ControlRequestRecipient recipient,
         ControlRequestStandard request,
@@ -14,7 +14,7 @@ public static class UsbDeviceExtension
         out ushort bytesRead,
         int timeout = Timeout.Infinite
     ) =>
-        device.ControlRead(
+        device.ControlRequestRead(
             recipient,
             ControlRequestType.Standard,
             (byte)request,
@@ -25,7 +25,7 @@ public static class UsbDeviceExtension
             timeout
         );
 
-    public static LibUsbResult ControlWrite(
+    public static LibUsbResult ControlRequestWrite(
         this IUsbDevice device,
         ControlRequestRecipient recipient,
         ControlRequestStandard request,
@@ -35,7 +35,7 @@ public static class UsbDeviceExtension
         out int bytesWritten,
         int timeout = Timeout.Infinite
     ) =>
-        device.ControlWrite(
+        device.ControlRequestWrite(
             recipient,
             ControlRequestType.Standard,
             (byte)request,

--- a/src/LibUsbSharp/UsbDeviceExtension.cs
+++ b/src/LibUsbSharp/UsbDeviceExtension.cs
@@ -4,7 +4,7 @@ namespace LibUsbSharp;
 
 public static class UsbDeviceExtension
 {
-    public static LibUsbResult ControlRequestRead(
+    public static LibUsbResult ControlRead(
         this IUsbDevice device,
         ControlRequestRecipient recipient,
         ControlRequestStandard request,
@@ -14,7 +14,7 @@ public static class UsbDeviceExtension
         out ushort bytesRead,
         int timeout = Timeout.Infinite
     ) =>
-        device.ControlRequestRead(
+        device.ControlRead(
             recipient,
             ControlRequestType.Standard,
             (byte)request,
@@ -25,7 +25,7 @@ public static class UsbDeviceExtension
             timeout
         );
 
-    public static LibUsbResult ControlRequestWrite(
+    public static LibUsbResult ControlWrite(
         this IUsbDevice device,
         ControlRequestRecipient recipient,
         ControlRequestStandard request,
@@ -35,7 +35,7 @@ public static class UsbDeviceExtension
         out int bytesWritten,
         int timeout = Timeout.Infinite
     ) =>
-        device.ControlRequestWrite(
+        device.ControlWrite(
             recipient,
             ControlRequestType.Standard,
             (byte)request,

--- a/src/LibUsbSharp/UsbInterfaceExtension.cs
+++ b/src/LibUsbSharp/UsbInterfaceExtension.cs
@@ -6,7 +6,7 @@ public static class UsbInterfaceExtension
         this IUsbInterface usbInterface,
         byte[] destination,
         out int bytesRead,
-        int timeout
+        int timeout = Timeout.Infinite
     ) => usbInterface.BulkRead(destination.AsSpan(), out bytesRead, timeout);
 
     public static LibUsbResult BulkWrite(
@@ -14,6 +14,6 @@ public static class UsbInterfaceExtension
         byte[] source,
         int count,
         out int bytesWritten,
-        int timeout
+        int timeout = Timeout.Infinite
     ) => usbInterface.BulkWrite(source.AsSpan(0, count), out bytesWritten, timeout);
 }

--- a/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
@@ -131,7 +131,7 @@ public sealed class Given_any_USB_device : IDisposable
         // this enables us to test that bytesRead returns expected length.
         var descriptorBuffer = new byte[32];
 
-        var result = device.ControlRequestRead(
+        var result = device.ControlRead(
             ControlRequestRecipient.Device,
             ControlRequestStandard.GetDescriptor,
             (DescriptorTypeDevice << 8) | DescriptorIndex,
@@ -167,7 +167,7 @@ public sealed class Given_any_USB_device : IDisposable
 
         // Start by getting current device configuration
         var readBuffer = new byte[1];
-        var readResult = device.ControlRequestRead(
+        var readResult = device.ControlRead(
             ControlRequestRecipient.Device,
             ControlRequestStandard.GetConfiguration,
             0,
@@ -181,7 +181,7 @@ public sealed class Given_any_USB_device : IDisposable
         }
 
         // When configuration read is successful, write the same config value back to the device
-        var writeResult = device.ControlRequestWrite(
+        var writeResult = device.ControlWrite(
             ControlRequestRecipient.Device,
             ControlRequestStandard.SetConfiguration,
             readBuffer[0],

--- a/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
@@ -119,6 +119,83 @@ public sealed class Given_any_USB_device : IDisposable
 #endif
     }
 
+    [SkippableFact]
+    public void ControlRead_returns_expected_descriptor_given_correct_Device_GetDescriptor_params()
+    {
+        const byte DescriptorTypeDevice = 0x01;
+        const ushort DescriptorIndex = 0x00;
+
+        using var device = _deviceSource.OpenUsbDeviceOrSkip();
+
+        // Allocate a slightly bigger buffer than the expected 18 bytes,
+        // this enables us to test that bytesRead returns expected length.
+        var descriptorBuffer = new byte[32];
+
+        var result = device.ControlRead(
+            ControlRequestRecipient.Device,
+            ControlRequestStandard.GetDescriptor,
+            (DescriptorTypeDevice << 8) | DescriptorIndex,
+            DescriptorIndex,
+            descriptorBuffer,
+            out var bytesRead
+        );
+
+        using var scope = new AssertionScope();
+        result.Should().Be(LibUsbResult.Success);
+
+        // USB Descriptor is always 18 bytes
+        bytesRead.Should().Be(18);
+        // Byte 4 is device class
+        ((UsbClass)descriptorBuffer[4])
+            .Should()
+            .Be(device.Descriptor.DeviceClass);
+        // Byte 8-9 is vendor ID
+        BitConverter.ToUInt16(descriptorBuffer[8..10], 0).Should().Be(device.Descriptor.VendorId);
+        // Byte 10-11 is product ID
+        BitConverter
+            .ToUInt16(descriptorBuffer[10..12], 0)
+            .Should()
+            .Be(device.Descriptor.ProductId);
+    }
+
+    [SkippableFact]
+    public void ControlWrite_is_successfull_given_params_to_set_current_Configuration()
+    {
+        const ushort DescriptorIndex = 0;
+
+        using var device = _deviceSource.OpenUsbDeviceOrSkip();
+
+        // Start by getting current device configuration
+        var readBuffer = new byte[1];
+        var readResult = device.ControlRead(
+            ControlRequestRecipient.Device,
+            ControlRequestStandard.GetConfiguration,
+            0,
+            0,
+            readBuffer,
+            out var bytesRead
+        );
+        if (readResult != LibUsbResult.Success && bytesRead == 1)
+        {
+            throw new SkipException($"ControlRead result '{readResult}', {bytesRead} bytes read.");
+        }
+
+        // When configuration read is successful, write the same config value back to the device
+        var writeResult = device.ControlWrite(
+            ControlRequestRecipient.Device,
+            ControlRequestStandard.SetConfiguration,
+            readBuffer[0],
+            DescriptorIndex,
+            [],
+            out var bytesWritten
+        );
+
+        using var scope = new AssertionScope();
+        writeResult.Should().Be(LibUsbResult.Success);
+        // We did not provide a payload, expect zero bytes written
+        bytesWritten.Should().Be(0);
+    }
+
     public void Dispose()
     {
         _libUsb.Dispose();

--- a/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
@@ -131,7 +131,7 @@ public sealed class Given_any_USB_device : IDisposable
         // this enables us to test that bytesRead returns expected length.
         var descriptorBuffer = new byte[32];
 
-        var result = device.ControlRead(
+        var result = device.ControlRequestRead(
             ControlRequestRecipient.Device,
             ControlRequestStandard.GetDescriptor,
             (DescriptorTypeDevice << 8) | DescriptorIndex,
@@ -167,7 +167,7 @@ public sealed class Given_any_USB_device : IDisposable
 
         // Start by getting current device configuration
         var readBuffer = new byte[1];
-        var readResult = device.ControlRead(
+        var readResult = device.ControlRequestRead(
             ControlRequestRecipient.Device,
             ControlRequestStandard.GetConfiguration,
             0,
@@ -181,7 +181,7 @@ public sealed class Given_any_USB_device : IDisposable
         }
 
         // When configuration read is successful, write the same config value back to the device
-        var writeResult = device.ControlWrite(
+        var writeResult = device.ControlRequestWrite(
             ControlRequestRecipient.Device,
             ControlRequestStandard.SetConfiguration,
             readBuffer[0],

--- a/tests/LibUsbSharp.Tests/Internal/LibUsbControlRequestSetupTest.cs
+++ b/tests/LibUsbSharp.Tests/Internal/LibUsbControlRequestSetupTest.cs
@@ -1,0 +1,40 @@
+﻿using LibUsbSharp.Internal.Transfer;
+
+namespace LibUsbSharp.Tests.Internal;
+
+public class LibUsbControlRequestSetupTest
+{
+    [Theory]
+    [InlineData(ControlRequestRecipient.Device, ControlRequestType.Standard, 0b10000000)]
+    [InlineData(ControlRequestRecipient.Interface, ControlRequestType.Standard, 0b10000001)]
+    [InlineData(ControlRequestRecipient.Endpoint, ControlRequestType.Standard, 0b10000010)]
+    [InlineData(ControlRequestRecipient.Endpoint, ControlRequestType.Class, 0b10100010)]
+    [InlineData(ControlRequestRecipient.Endpoint, ControlRequestType.Vendor, 0b11000010)]
+    public void Read_returns_expected_setup_packet_request_byte(
+        ControlRequestRecipient recipient,
+        ControlRequestType type,
+        byte expectedValue
+    )
+    {
+        var setup = LibUsbControlRequestSetup.Read(recipient, type, 0, 0, 0, 0);
+        var buffer = setup.CreateBuffer();
+        buffer[0].Should().Be(expectedValue, Convert.ToString(buffer[0], 2).PadLeft(8, '0'));
+    }
+
+    [Theory]
+    [InlineData(ControlRequestRecipient.Device, ControlRequestType.Standard, 0b00000000)]
+    [InlineData(ControlRequestRecipient.Interface, ControlRequestType.Standard, 0b00000001)]
+    [InlineData(ControlRequestRecipient.Endpoint, ControlRequestType.Standard, 0b00000010)]
+    [InlineData(ControlRequestRecipient.Endpoint, ControlRequestType.Class, 0b00100010)]
+    [InlineData(ControlRequestRecipient.Endpoint, ControlRequestType.Vendor, 0b01000010)]
+    public void Write_returns_expected_setup_packet_request_byte(
+        ControlRequestRecipient recipient,
+        ControlRequestType type,
+        byte expectedValue
+    )
+    {
+        var setup = LibUsbControlRequestSetup.Write(recipient, type, 0, 0, 0, 0);
+        var buffer = setup.CreateBuffer();
+        buffer[0].Should().Be(expectedValue);
+    }
+}


### PR DESCRIPTION
Implement UsbDevice ControlRequest read/write using existing LibUsbTransfer.ExecuteSync method. Given a connected USB device; test that reading and writing ControlRequests works as expected.

Based on @pkhansen's work on adding USB video device UVC support to the project. The code in this PR will help facilitate UVC in a way that works with the LibUsbSharp async IO libusb API integration.