### PR TITLE
Test and use appropriate exception/message on device/interface re-open

### DIFF
--- a/src/LibUsbSharp/LibUsb.cs
+++ b/src/LibUsbSharp/LibUsb.cs
@@ -225,7 +225,7 @@ public sealed class LibUsb : ILibUsb
             CheckDisposed();
             if (_openDevices.ContainsKey(deviceKey))
             {
-                throw new InvalidOperationException($"Device '{LibraryName}' already open.");
+                throw new InvalidOperationException($"Device '{deviceKey}' already open.");
             }
             var context = GetInitializedContextOrThrow();
             return OpenDeviceUnlocked(context, deviceKey);

--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -210,7 +210,7 @@ public sealed class UsbDevice : IUsbDevice
         {
             if (_claimedInterfaces.TryGetValue(descriptor.InterfaceNumber, out var existing))
             {
-                throw new ArgumentException($"USB interface {existing} already claimed.");
+                throw new InvalidOperationException($"USB interface {existing} already claimed.");
             }
 
             // TODO: libusb_set_auto_detach_kernel_driver on Linux?

--- a/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
@@ -49,6 +49,15 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
     }
 
     [SkippableFact]
+    public void Device_throws_InvalidOperationException_when_trying_to_claim_interface_twice()
+    {
+        using var device = _deviceSource.OpenUsbDeviceOrSkip();
+        using var usbInterface = device.ClaimInterface(UsbClass.VendorSpecific);
+        var act = () => device.ClaimInterface(UsbClass.VendorSpecific);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already claimed*");
+    }
+
+    [SkippableFact]
     public void Device_is_able_to_claim_interface_and_get_an_output_endpoint()
     {
         using var device = _deviceSource.OpenUsbDeviceOrSkip();


### PR DESCRIPTION
Test and use appropriate exception/message on device re-open and interface re-claim attempts